### PR TITLE
Fix compact filter test case

### DIFF
--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -643,6 +643,9 @@ rocksdb::ColumnFamilyHandle *Storage::GetCFHandle(const std::string &name) {
 rocksdb::Status Storage::Compact(const Slice *begin, const Slice *end) {
   rocksdb::CompactRangeOptions compact_opts;
   compact_opts.change_level = true;
+  // For the manual compaction, we would like to force the bottommost level to be compacted.
+  // Or it may use the trivial mode and some expired key-values were still exist in the bottommost level.
+  compact_opts.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForceOptimized;
   for (const auto &cf_handle : cf_handles_) {
     rocksdb::Status s = db_->CompactRange(compact_opts, cf_handle, begin, end);
     if (!s.ok()) return s;


### PR DESCRIPTION
RocksDB compaction allows to use of trivial move mode(move file into the next level instead of using compaction filter to generate the output file) when the compaction is not triggered by the manual way.

So after this fix, `NeedCompact` will return the correct result and then wait for the background compaction schedule(become no manual way so it allows the trivial move), so after we call the `storage->Compact`, it won't manually compact the moved file. 

I fixed this issue by using force bottom-level compaction when triggering the manual compaction, it's our expected behavior.

See https://github.com/facebook/rocksdb/blob/ba597514309b686d8addb59616f067d5522186b7/db/db_impl/db_impl_compaction_flush.cc#L3358